### PR TITLE
feat: add mermaid-markdown-wrap as reference submodule

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -150,7 +150,9 @@
       "Bash(../dist/presentation/cli.js init --yes)",
       "Bash(git push:*)",
       "Bash(git commit:*)",
-      "Bash(git add:*)"
+      "Bash(git add:*)",
+      "Bash(git submodule add:*)",
+      "Bash(git submodule:*)"
     ],
     "deny": []
   },

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "reference/mermaid-markdown-wrap"]
+	path = reference/mermaid-markdown-wrap
+	url = https://github.com/sugurutakahashi-1234/mermaid-markdown-wrap.git
+	ignore = all

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,3 +94,169 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ### Requirements
 - **Node.js**: v20 以上
 - **bun**: 最新版
+
+readme‑i18n‑sentinel 企画書（改訂版）
+目的: README を中心とした「多言語ドリフト（原文変更に対して翻訳が追随していない状態）」を、ローカルで素早く検知し、開発フローに自然に組み込める軽量 CLI を提供する。
+
+1. プロダクト定義
+* 製品名: readme‑i18n‑sentinel（以下、Sentinel）
+* 形態: npm 配布の ローカル専用 CLI（husky, lint-staged 等のフックから呼び出す前提）
+* 対象: Markdown ベースの README とその翻訳版（任意で他の .md ファイルにも適用可能）
+* 非目標: 翻訳そのものの生成/編集、GitHub Actions 専用実装、TMS（Crowdin 等）との直接連携、PR コメント機能
+
+2. ゴール / 非ゴール
+ゴール
+1. 原文（例: docs/README.md）の変更に対して、翻訳ファイル群（例: README.ja.md, README.zh-CN.md）が最新かどうかを即時判定
+2. 行単位の厳密チェックを基本としつつ、必要な検査はコンフィグファイルでオン/オフ可能（モードは採用しない）
+3. 設定は 単一のコンフィグ（TS/ESM または YAML/JSON） に集約。CLI での上書きは不可（-c/--config のみ）
+4. 結果は 終了コード（0/1）と 人間可読なレポート、機械可読(JSON) の 3 形態で出力
+5. husky の pre-commit / pre-push、ローカル手動実行にストレス無く組み込める
+非ゴール
+* 自動翻訳、誤訳検出、テキスト意味解析
+* GitHub 専用機能（Actions のラッパー、PR コメント投稿など）
+* Markdown 以外（JSON/PO 等）の専用サポート（将来の拡張候補には残す）
+
+3. 主要ユースケース
+1. コミット直前に原文だけ変更 → 翻訳未追随を検出してコミットをブロック
+2. 翻訳だけの修正コミット → チェックを自動スキップ（原文が未変更のため）
+3. 一部言語だけ先に更新 → 未更新の言語をリストアップして通知
+4. 緊急対応で一時スキップ → husky の commit-msg で特別キーワードを検知し、Sentinel の実行をスキップ（CLI 側のスキップ機能は持たない）
+5. 定期点検 → 手動実行で全翻訳の整合性レポートを取得
+
+4. 検査の設計（固定ルール／CLIでの切替なし）
+シンプルさを優先し、モードや切替フラグは無し。常に同じ検査セットを実行します。
+常時有効な検査セット
+1. lines: 原文と各翻訳の 総行数一致 を確認。
+2. changes: git diff --unified=0 で抽出した 変更行番号 が、翻訳側でも 同じ行で更新 されているか確認。
+3. headingsMatchSource: 見出し（#, ##, ...）の レベルとテキストの完全一致 を要求。多言語であっても見出しは 原文（例: 英語）を共通化。
+比較の事前正規化（内部で自動・設定不要）
+* 空白・改行などの一般的な正規化のみを内部実装で自動適用
+※ 正規化は「誤検知を減らすための恒久ルール」として実装し、v1 では設定から変更できません（設定の最小化）。
+
+5. CLI 仕様（極小インターフェース）
+* 既定コマンド（サブコマンドなし）: readme-i18n-sentinel ・・・ 検査を実行（終了コード 0/1/2）
+    * オプション: -c, --config <path>（設定ファイルを明示）
+* 補助サブコマンド:
+    * init …… 最小構成の設定ファイルを生成
+    * validate …… 設定ファイルのスキーマ検証のみを行い、問題があれば詳細を表示（終了コード 2）
+方針: フラグは -c/--config のみ。他の切替は すべてコンフィグ側 で定義する。原文変更の検知やスキップ制御は husky 側 に任せる。
+
+6. 設定ファイル（できるだけシンプル）
+# readme-i18n-sentinel.config.(yml|yaml|json|ts|mjs|mts)
+# ESM/TS は `export default { ... }` を前提
+source: docs/README.md
+targets:
+  - docs/README.ja.md
+  - docs/README.zh-CN.md
+checks:               # v1 では既定すべて true。必要なら false にできる
+  lines: true
+  changes: true
+  headingsMatchSource: true
+output:
+  json: false         # true で CLI 出力を JSON（stdout）に固定
+* 意味
+    * source: 原文 README のパス
+    * targets: 翻訳ファイルのパス配列（順序不問）
+    * checks: 3 つの検査の ON/OFF（CLI からは変更不可）
+    * output.json: 出力形式（JSON/Text）
+* 設定の発見ルール: カレントから readme-i18n-sentinel.config.(yml|yaml|json|ts|mjs|mts) を探索。見つからない場合は package.json > readmeI18nSentinel を参照。-c 指定があればそれを優先。
+* バリデーション: Zod による実行時検証 で厳格検証（必須/型/配列長≥1/未知キー禁止）。
+---yaml
+readme-i18n-sentinel.config.(yml|yaml|json|ts|mjs|mts)
+ESM/TS は export default { ... } を前提
+source: docs/README.mdtargets:
+* docs/README.ja.md
+* docs/README.zh-CN.mdjson: false # true にすると CLI 出力を JSON（stdout）に固定
+- **意味**
+  - `source`: 原文 README のパス
+  - `targets`: 翻訳ファイルのパス配列（順序不問）
+  - `json`: 出力形式。`true` なら JSON、`false` ならテキスト（既定: `false`）
+
+- **設定の発見ルール**: カレントから `readme-i18n-sentinel.config.(yml|yaml|json|ts|mjs|mts)` を探索。見つからない場合は `package.json > readmeI18nSentinel` を参照。`-c` 指定があればそれを優先。
+- **バリデーション**: **Zod による実行時検証** で厳格検証（必須/型/配列長≥1/未知キー禁止）。
+
+---
+
+## 7. 入出力仕様
+### 入力
+- Git リポジトリであること（`git diff` を使用）
+- `source` と `targets`（設定から取得）
+
+### 出力
+- **終了コード**: 0=OK / 1=Outdated / 2=設定エラー
+- **形式**: `json: false` の場合は **テキスト**（人が読むログを stderr）、`json: true` の場合は **JSON** を stdout にのみ出力
+- **テキスト例**
+  - `❌ ja.md: 42 行目が未反映`
+  - `❌ zh-CN.md: 総行数不一致 (120 ≠ 118)`
+  - `❌ ja.md: 見出し不一致 => "## Getting Started"`
+  - `✅ 全言語最新`
+- **JSON 例**
+```json
+{
+  "ok": false,
+  "errors": [
+    {"file":"docs/README.ja.md","type":"line-missing","line":42},
+    {"file":"docs/README.zh-CN.md","type":"headings-mismatch","heading":"## Getting Started"}
+  ]
+}
+
+8. スキップ & 実行設計（husky 前提）
+* 原文変更の検知: pre-commit で git diff --cached --name-only | grep '^docs/README.md$' を条件に実行。
+* スキップ: commit-msg フックでコミットメッセージに [i18n-skip] が含まれる場合は Sentinel を呼ばない（ツール本体にスキップ機能は持たせない）。
+サンプル
+# .husky/pre-commit
+if git diff --cached --name-only | grep -q '^docs/README.md$'; then
+  npx readme-i18n-sentinel -c ./readme-i18n-sentinel.config.yml || exit 1
+fi
+
+# .husky/commit-msg
+MSG_FILE="$1"
+if grep -q "\[i18n-skip\]" "$MSG_FILE"; then
+  exit 0
+fi
+Sentinel は 実行時の切替フラグを持たず、挙動は常に一定。実行する/しないの判定は husky 側で完結。
+
+9. 互換性・パフォーマンス・制約
+* Node.js 18+、ESM 専用（type: module）。CJS はサポートしない
+* 設定ファイルに TypeScript/ESM をサポート（.ts/.mts/.mjs は export default を前提）
+* 1,000 行規模の README × 3 言語で 300ms 以内（ローカル SSD 想定）
+* 行末・改行コード（LF/CRLF）は自動正規化
+* Fenced code block 内は既定で対象外（将来設定で切替）
+
+10. エラー設計
+* 設定ファイルが無い/不正 → コード 2 + スキーマ差分を表示
+* 原文/翻訳が見つからない → コード 1（運用上のエラーとして扱う）
+* Git 操作に失敗 → コード 2（環境エラー）
+
+11. セキュリティ / プライバシー
+* ネットワークアクセス無し。ローカルファイルと Git 差分のみを扱う
+* テレメトリ無し
+
+12. 品質保証（最低限のテスト方針）
+* ユニット: 行数一致、変更行抽出、見出し一致の 3 検査関数
+* フィクスチャ: 正常／行ズレ／未反映／見出し不一致
+* クロスプラットフォーム: macOS / Ubuntu / Windows（改行差）
+
+13. ロードマップ
+* v0.1: 固定検査（lines/changes/headingsMatchSource）+ 単一設定 + JSON 出力 + init/validate
+* v0.2: 無視範囲コメント（<!-- sentinel:ignore start/end -->）+ 改行/空白の正規化強化
+* v1.0: スキーマ安定化・性能最適化
+
+14. 開発メモ（AI コーディング支援向け）
+* 依存候補: cosmiconfig + cosmiconfig-typescript-loader（TS/ESM 設定読み込み）、ajv（JSON Schema バリデーション）、simple-git
+* 実装順序: loader（ESM/TS 読込 + Ajv 検証）→ diff 抽出 → 判定（lines/changes/headings）→ レポータ → CLI → init/validate
+* バリデーション選択: Zod（推奨）
+    * 長所: TS-first の単一ソース。configSchema.parse(obj) だけで実行時検証／デフォルト付与（.default()）／追加制約（refine）が可能
+    * IDE 連携: zod-to-json-schema で JSON Schema を生成し $schema に指定すれば YAML/JSON の補完も効く
+    * 代替案: Ajv を使う場合は JSON Schema 起点で設計。もしくは Zod→JSON Schema 生成 → Ajv 実行のハイブリッド
+* 最小インターフェース案:interface Config { source:string; targets:string[]; checks?:{lines?:boolean;changes?:boolean;headingsMatchSource?:boolean}; output?:{json?:boolean} }
+* type ErrorType = 'lines-mismatch'|'line-missing'|'headings-mismatch';
+* interface ErrorItem { file:string; type:ErrorType; line?:number; heading?:string }
+* interface Result { ok:boolean; errors: ErrorItem[] }
+* ```ts
+* interface Config { source:string; targets:string[]; checks?:{lines?:boolean;changes?:boolean;headingsMatchSource?:boolean}; output?:{json?:boolean} }
+* type ErrorType = 'lines-mismatch'|'line-missing'|'headings-mismatch';
+* interface ErrorItem { file:string; type:ErrorType; line?:number; heading?:string }
+* interface Result { ok:boolean; errors: ErrorItem[] }
+* 
+備考: GitHub Actions は対象外。ローカル体験に集中し、将来必要なら同 CLI を CI から呼ぶだけで済む設計。

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,5 +1,8 @@
 {
   "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
+  "files": {
+    "includes": ["**", "!**/reference/**"]
+  },
   "vcs": {
     "enabled": true,
     "clientKind": "git"


### PR DESCRIPTION
## Summary
- Add mermaid-markdown-wrap as a read-only reference submodule for implementation guidance
- Configure proper ignore settings to prevent accidental modifications

## Changes
- Add `reference/mermaid-markdown-wrap` submodule with `ignore = all` in `.gitmodules`
- Update `biome.jsonc` to exclude reference directory from linting/formatting
- This allows us to reference the implementation without affecting our codebase

## Test plan
- [x] Verify submodule is properly added
- [x] Confirm changes within submodule are ignored by git status
- [x] Ensure biome doesn't process files in reference directory
- [x] All CI checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)